### PR TITLE
Prod 2714 filter passwords again

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,32 +76,16 @@ it is left upto you to add them. Here's how to do it:
       end
     end
 
-### Filtering out controller params
-
-You may not want to log certain parameters which have sensitive information in
-them, e.g. `password`. This can be set using the `filter_parameters` option:
-
-    # Filter out some field you don't want to show
-    config.logstasher.filter_parameters << 'foo'
-
-Note that by default this is set to `['password', 'password_confirmation']`, so
-be careful when explicitly setting, as you may lose this filtering:
-
-    # NOTE: password and password_confirmation will no longer be filtered
-    config.logstasher.filter_parameters = ['foo']
-
-Any filtered parameter will still show in the `params` field, but it's value
-will be `[FILTERED]`.
-
 ## Installation for Grape Application
 
-### In your Gemfile:
+### In your Gemfile: 
 
     gem "rv-logstasher"
     gem "grape_logging"
-
+    
+    
 ### Init logger:
-
+    
     module TestApp
       def self.logger
         @logger ||= LogStasher.logger_for_app('app_name', Rack::Directory.new("").root, STDOUT)
@@ -109,14 +93,14 @@ will be `[FILTERED]`.
     end
 
 ### Setup Grape request/exception logging
-
+     
     module TestApp
       class API < Grape::API
         logger TestApp.logger
         use GrapeLogging::Middleware::RequestLogger, logger: TestApp.logger
-
+        
         rescue_from TestApp::NotFound do |err|
-          # Tag your exception
+          # Tag your exception 
           API.logger.info(exception: err, tags: "rescued_exception", status: 404)
           error_response(message: "Not found", status: 404)
         end
@@ -127,6 +111,8 @@ will be `[FILTERED]`.
         end
       end
     end
+
+
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -76,16 +76,32 @@ it is left upto you to add them. Here's how to do it:
       end
     end
 
+### Filtering out controller params
+
+You may not want to log certain parameters which have sensitive information in
+them, e.g. `password`. This can be set using the `filter_parameters` option:
+
+    # Filter out some field you don't want to show
+    config.logstasher.filter_parameters << 'foo'
+
+Note that by default this is set to `['password', 'password_confirmation']`, so
+be careful when explicitly setting, as you may lose this filtering:
+
+    # NOTE: password and password_confirmation will no longer be filtered
+    config.logstasher.filter_parameters = ['foo']
+
+Any filtered parameter will still show in the `params` field, but it's value
+will be `[FILTERED]`.
+
 ## Installation for Grape Application
 
-### In your Gemfile: 
+### In your Gemfile:
 
     gem "rv-logstasher"
     gem "grape_logging"
-    
-    
+
 ### Init logger:
-    
+
     module TestApp
       def self.logger
         @logger ||= LogStasher.logger_for_app('app_name', Rack::Directory.new("").root, STDOUT)
@@ -93,14 +109,14 @@ it is left upto you to add them. Here's how to do it:
     end
 
 ### Setup Grape request/exception logging
-     
+
     module TestApp
       class API < Grape::API
         logger TestApp.logger
         use GrapeLogging::Middleware::RequestLogger, logger: TestApp.logger
-        
+
         rescue_from TestApp::NotFound do |err|
-          # Tag your exception 
+          # Tag your exception
           API.logger.info(exception: err, tags: "rescued_exception", status: 404)
           error_response(message: "Not found", status: 404)
         end
@@ -111,8 +127,6 @@ it is left upto you to add them. Here's how to do it:
         end
       end
     end
-
-
 
 ## Copyright
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -69,6 +69,14 @@ module LogStasher
 
       @silence_standard_logging
     end
+
+    def filter_parameters
+      @filter_parameters ||= ['password', 'password_confirmation']
+    end
+
+    def filter_paramterss=(params)
+      @filter_paramterss = params
+    end
   end
 end
 

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -69,14 +69,6 @@ module LogStasher
 
       @silence_standard_logging
     end
-
-    def filter_parameters
-      @filter_parameters ||= ['password', 'password_confirmation']
-    end
-
-    def filter_parameters=(params)
-      @filter_parameters = params
-    end
   end
 end
 

--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -93,9 +93,6 @@ module LogStasher
     def extract_parameters(payload)
       if LogStasher.include_parameters?
         external_params = payload[:params].except(*INTERNAL_PARAMS)
-        LogStasher.filter_parameters.each do |param|
-          external_params[param] = '[FILTERED]' unless external_params[param].nil?
-        end
 
         if LogStasher.serialize_parameters?
           { :params => JSON.generate(external_params) }

--- a/lib/logstasher/version.rb
+++ b/lib/logstasher/version.rb
@@ -1,3 +1,3 @@
 module LogStasher
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end

--- a/spec/lib/logstasher/log_formater_spec.rb
+++ b/spec/lib/logstasher/log_formater_spec.rb
@@ -99,6 +99,39 @@ describe LogStasher::LogFormatter do
         })
       end
     end
+
+    context 'when the hash contains filtered parameters' do
+      describe 'defaults' do
+        let(:data) do
+          {
+            params: {
+              'password' => '1337passWORD',
+              'password_confirmation' => '1337passWORD'
+            }
+          }
+        end
+
+        it 'filters out password and password_confirmation' do
+          expect(format).to match(
+            params: {
+              'password' => '[FILTERED]',
+              'password_confirmation' => '[FILTERED]'
+            }
+          )
+        end
+      end
+
+      context 'with specified filtering' do
+        let(:data) { {params: {'foo' => 'bar', 'blah' => 'something'}} }
+        before(:each) do
+          allow(::LogStasher).to receive(:filter_parameters).and_return(['foo'])
+        end
+
+        it 'filters out the specified fields only' do
+          expect(format).to match(params: {'foo' => '[FILTERED]', 'blah' => 'something'})
+        end
+      end
+    end
   end
 
   describe '#call' do

--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -35,12 +35,11 @@ describe LogStasher::LogSubscriber do
   describe '#process_action' do
     let(:timestamp) { ::Time.new.utc.iso8601(3) }
     let(:duration) { 12.4 }
-    let(:params) { {'foo' => 'bar'} }
     let(:json_params) { JSON.dump(payload[:params]) }
     let(:payload) {{
       :controller => 'users',
       :action     => 'show',
-      :params     => params,
+      :params     => { 'foo' => 'bar' },
       :format     => 'text/plain',
       :method     => 'method',
       :path       => '/users/1',
@@ -104,32 +103,6 @@ describe LogStasher::LogSubscriber do
       end
 
       subject.process_action(event)
-    end
-
-    it 'can be configured to filter out certain parameters' do
-      allow(::LogStasher).to receive(:filter_parameters).and_return(['foo'])
-
-      expect(logger).to receive(:<<) do |json|
-        expect(JSON.parse(json)['params']).to eq('{"foo":"[FILTERED]"}')
-      end
-
-      subject.process_action(event)
-    end
-
-    context 'with passwords in parameters' do
-      let(:params) do
-        {'password' => '1337passWORD', 'password_confirmation' => '1337passWORD'}
-      end
-
-      it 'filters them out by default' do
-        expect(logger).to receive(:<<) do |json|
-          expect(JSON.parse(json)['params']).to eq(
-            '{"password":"[FILTERED]","password_confirmation":"[FILTERED]"}'
-          )
-        end
-
-        subject.process_action(event)
-      end
     end
 
     it 'includes redirect location in the log' do


### PR DESCRIPTION
This is basically the same change as that made in commit d3a2557, which
had the right logic but was in the wrong place (see reversion commit
6f0fea1) and essentially was a no-op.

The apps which use this well generally set their Logger.formatter as the
LogStasher::LogFormatter, which is where this change belongs.

Original commit message:

When using Grape/Rack instead of Rails, we don't automatically get
passwords filtered out from logging (see section 6.4 Logging in the
Rails guides: http://guides.rubyonrails.org/security.html#logging)

I've used the same format as Rails for the ouptut ('[FILTERED]') to keep
it consistent with how our logs appear in logstash, etc where we have
Rails app logs as well.')

---

This time though, I've actively tested it by running an app, rather than assuming I know what I'm doing and just using rspec....
